### PR TITLE
fix(QUAL-040): ダッシュボードデータマッピング問題修正

### DIFF
--- a/features/common/dashboard_generator.py
+++ b/features/common/dashboard_generator.py
@@ -54,8 +54,8 @@ class StandardDashboardGenerator:
         
         # 基本統計
         total = data.get('total_images', 0)
-        successful = data.get('successful_extractions', 0)
-        avg_quality = data.get('average_quality_score', 0.0)
+        successful = data.get('success_count', 0)
+        avg_quality = data.get('summary', {}).get('average_quality_score', 0.0)
         
         # 画像リスト（extraction_resultsとresults両方に対応）
         results = data.get('extraction_results', data.get('results', []))
@@ -64,7 +64,7 @@ class StandardDashboardGenerator:
         quality_dist = {'高品質': 0, '中品質': 0, '低品質': 0, '要改善': 0}
         for r in results:
             if r.get('success'):
-                score = r.get('quality_score', 0.0)
+                score = r.get('quality_metrics', {}).get('overall_score', 0.0)
                 if score >= 0.8:
                     quality_dist['高品質'] += 1
                 elif score >= 0.6:
@@ -141,8 +141,10 @@ class StandardDashboardGenerator:
         # 画像カード生成
         for r in results:
             if r.get('success'):
-                filename = r.get('image_name', r.get('filename', 'unknown.jpg'))
-                score = r.get('quality_score', 0.0)
+                # image_pathから実際のファイル名を抽出
+                image_path = r.get('image_path', 'unknown.jpg')
+                filename = image_path.split('/')[-1] if '/' in image_path else image_path
+                score = r.get('quality_metrics', {}).get('overall_score', 0.0)
                 quality_label = self._get_quality_label(score)
                 quality_class = self._get_quality_class(score)
                 


### PR DESCRIPTION
## 🐛 問題の概要

QUAL-040ダッシュボードで以下の問題が発生：
- 全画像が "unknown.jpg" として表示
- 平均品質スコアが 0.000 で固定表示
- 成功画像数が 0 で表示
- 実際のextraction_result.jsonには正しいデータが存在

## 🔧 修正内容

### 1. 基本統計フィールド名修正
```python
# Before (間違ったフィールド名)
successful = data.get('successful_extractions', 0)

# After (正しいフィールド名)
successful = data.get('success_count', 0)
```

### 2. 品質スコア取得パス修正
```python
# Before (間違ったパス)
avg_quality = data.get('average_quality_score', 0.0)

# After (正しいパス)
avg_quality = data.get('summary', {}).get('average_quality_score', 0.0)
```

### 3. 品質分布・画像カード用スコア修正
```python
# Before (存在しないフィールド)
score = r.get('quality_score', 0.0)

# After (正しいネストしたパス)
score = r.get('quality_metrics', {}).get('overall_score', 0.0)
```

### 4. 画像ファイル名抽出修正
```python
# Before (フォールバック値のみ)
filename = r.get('image_name', r.get('filename', 'unknown.jpg'))

# After (image_pathから実際のファイル名抽出)
image_path = r.get('image_path', 'unknown.jpg')
filename = image_path.split('/')[-1] if '/' in image_path else image_path
```

## 📊 Before/After比較

### ❌ Before (修正前)
- **総画像数**: 6
- **平均品質スコア**: 0.000 ❌
- **成功画像数**: 0 ❌
- **画像表示**: unknown.jpg × 6個 ❌
- **品質バッジ**: 全て「要改善」❌

### ✅ After (修正後)
- **総画像数**: 6
- **平均品質スコア**: 0.308 ✅
- **成功画像数**: 6 ✅
- **品質分布**: 低品質2個、要改善4個 ✅
- **画像表示**: 実際のファイル名表示 ✅
  - `extracted_kana05_0000_cover.jpg`
  - `extracted_kana05_0001.jpg`
  - `extracted_kana05_0002.jpg`
  - `extracted_kana05_0003.jpg`
  - `extracted_kana05_0004.jpg` 
  - `kana05_0001.jpg`

## 🧪 検証方法

```bash
# ダッシュボード生成
python3 tools/scripts/unified_dashboard_wrapper.py QUAL-040 \
  /mnt/c/AItools/lora/train/yado/tracker-workspace/QUAL-040/extraction \
  /mnt/c/AItools/lora/train/yado/tracker-workspace/QUAL-040

# 結果確認
cat /mnt/c/AItools/lora/train/yado/tracker-workspace/QUAL-040/dashboard/dashboard.html
```

## 📁 影響範囲

- **修正ファイル**: `features/common/dashboard_generator.py`
- **影響システム**: 統合ダッシュボード生成システム
- **後方互換性**: 維持（extraction_resultsとresults両対応）

## ✅ テスト結果

- ✅ 実際のデータ正常表示確認
- ✅ 6画像全ての品質バッジ色分け正常
- ✅ ファイルパス形式正常（/QUAL-040/extraction/xxx.jpg）

🤖 Generated with [Claude Code](https://claude.ai/code)