### PR TITLE
chore(ci): add Codecov coverage upload

### DIFF
--- a/.github/workflows/full-test-ci.yml
+++ b/.github/workflows/full-test-ci.yml
@@ -305,6 +305,13 @@ jobs:
           htmlcov/
         retention-days: 30
 
+    - name: Upload coverage to Codecov
+      if: always()
+      uses: codecov/codecov-action@v5
+      with:
+        files: coverage-unit.xml,coverage-integration.xml,coverage-extraction.xml,coverage-qc.xml,coverage-workflow.xml,coverage-root.xml
+        fail_ci_if_error: false
+
     - name: 📝 Test Report Summary
       if: always()
       run: |


### PR DESCRIPTION
## Summary
- Add `codecov/codecov-action@v5` upload step to `full-test-ci.yml`
- Uploads all coverage XML files (unit, integration, extraction, qc, workflow, root)
- Tokenless upload (Codecov GitHub App installed)

## Test plan
- [ ] CI passes on this PR
- [ ] Codecov dashboard shows coverage report

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * テストカバレッジレポート機能を強化しました。複数のテストスイート対象のカバレッジデータをより包括的に収集・報告できるようになり、コード品質の監視がさらに充実しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->